### PR TITLE
Add GitHub Actions build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  Build:
+    runs-on: ubuntu-18.04
+    env:
+        LANG: en_US.UTF-8
+        LANGUAGE: en_US:en
+        LC_ALL: en_US.UTF-8
+    steps:
+    - uses: actions/checkout@master
+    - name: Install dependencies
+      run: sudo dpkg --add-architecture i386 && sudo apt-get update && sudo apt-get install -y bc build-essential cpio dosfstools g++-multilib gdisk git-core libncurses5-dev libncurses5-dev:i386 python squashfs-tools sudo unzip wget locales autoconf nasm rsync
+    - name: Configure sedutil
+      run: autoreconf --install && ./configure
+    - name: Build sedutil
+      run: make all
+    - name: List built binary
+      run: ls -l sedutil-cli
+    - name: Upload sedutil binary artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: sedutil-cli-${{ github.sha }}
+        path: sedutil-cli
+    - name: Build resources
+      run: cd images && ./getresources
+    - name: Build 64bit and 32bit PBA Linux system
+      run: cd images && ./buildpbaroot
+    - name: Build BIOS
+      run: cd images && ./buildbios
+    - name: Build UEFI64
+      run: cd images && ./buildUEFI64
+    - name: Build Rescue32
+      run: cd images && ./buildrescue Rescue32
+    - name: Build Rescue64
+      run: cd images && ./buildrescue Rescue64
+    - name: List built files
+      run: ls -l sedutil-* images/*/*.gz
+    - name: Upload source code artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: sedutil-source-${{ github.sha }}
+        path: sedutil-*.tar.gz
+    - name: Upload image artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: sedutil-images-${{ github.sha }}
+        path: images/*/*.img.gz

--- a/images/buildUEFI64
+++ b/images/buildUEFI64
@@ -17,13 +17,13 @@ BUILDIMG=${BUILDTYPE}-$(printf '%s' "$VERSIONINFO" | tr '/' '-').img
 IMAGE_DIR=$BUILDTYPE/image
 TARGET_DIR=$IMAGE_DIR/$BOOTLOADER_DIR
 
-EFI_FILE="scratch/${SYSLINUX}/efi64/efi/syslinux.efi"
-IMAGE_FILES="scratch/${SYSLINUX}/efi64/com32/elflink/ldlinux/ldlinux.e64
-    scratch/buildroot/64bit/images/bzImage
-    scratch/buildroot/64bit/images/rootfs.cpio.xz
-    scratch/buildroot/64bit/target/sbin/linuxpba
-    scratch/buildroot/64bit/target/sbin/sedutil-cli
-    buildroot/syslinux.cfg"
+EFI_FILE="${PWD}/scratch/${SYSLINUX}/efi64/efi/syslinux.efi"
+IMAGE_FILES="${PWD}/scratch/${SYSLINUX}/efi64/com32/elflink/ldlinux/ldlinux.e64
+    ${PWD}/scratch/buildroot/64bit/images/bzImage
+    ${PWD}/scratch/buildroot/64bit/images/rootfs.cpio.xz
+    ${PWD}/scratch/buildroot/64bit/target/sbin/linuxpba
+    ${PWD}/scratch/buildroot/64bit/target/sbin/sedutil-cli
+    ${PWD}/buildroot/syslinux.cfg"
 
 ## Exit handlers ##############################################################
 rm_temporaries() {
@@ -93,10 +93,10 @@ create_image() {
     mkdir -p ${VERBOSE+-v} -- "$IMAGE_DIR"
     sudo mount ${VERBOSE+-v} -- "${LOOPDEV}" "$IMAGE_DIR"
     trap 'unmount_image; detach_lo_device; rm_temporaries' EXIT
-    sudo install ${VERBOSE+-v} -D -- "../$EFI_FILE" "${TARGET_DIR}/$BOOTLOADER_FILE"
+    sudo install ${VERBOSE+-v} -D -- "$EFI_FILE" "${TARGET_DIR}/$BOOTLOADER_FILE"
     # shellcheck disable=SC2086
     for f in $IMAGE_FILES; do
-        sudo install ${VERBOSE+-v} -D -- ../$f "$TARGET_DIR"
+        sudo install ${VERBOSE+-v} -D -- "$f" "$TARGET_DIR"
     done
     sync
     gzip -k ${VERBOSE+-v} "$BUILDIMG"

--- a/images/buildroot/packages/sedutil/sedutil.hash
+++ b/images/buildroot/packages/sedutil/sedutil.hash
@@ -1,0 +1,1 @@
+none xxx sedutil-1.16.0.tar.gz


### PR DESCRIPTION
This change adds a free GitHub Actions build on every commit and pull request:
- the build verifies if the build chain is working
- total build time is about 2 hours.
- the sedutil-cli binary, generated source tree and images are uploaded as artifacts and are available for download, testing and debugging