### PR TITLE
Fix an includes issue in SecureContainer.h

### DIFF
--- a/Common/SecureContainer.h
+++ b/Common/SecureContainer.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <string>
 #include <vector>
 #ifdef __linux__
 #include <memory>
@@ -35,7 +36,6 @@ template <class T> class SecureAllocator : public std::allocator<T>
 typedef std::basic_string<char, std::char_traits<char>, SecureAllocator<char>> SecureString;
 typedef std::vector<uint8_t, SecureAllocator<uint8_t>> SecureByteVector;
 #else
-#include <string>
 typedef std::string SecureString;
 typedef std::vector<uint8_t> SecureByteVector;
 #endif //__linux__


### PR DESCRIPTION
The use of `std::basic_string` requires `<string>`.

This issue was causing [GetNetPassPhrase.cpp](https://github.com/ladar/sedutil/blob/master/LinuxPBA/GetNetPassPhrase.cpp) compilation to fail for me.

We don't see the same failures elsewhere only because `<string>` is included indirectly in other files:
`os.h` -> `log.h` -> `<string>`